### PR TITLE
Avoid modifying r->args.data, which breaks the $arg_name in nginx

### DIFF
--- a/services/nginz/third_party/nginx-zauth-module/zauth_module.c
+++ b/services/nginz/third_party/nginx-zauth-module/zauth_module.c
@@ -309,7 +309,8 @@ static ngx_int_t zauth_parse_request (ngx_http_request_t * r) {
                         return NGX_ERROR;
                 }
                 u_char* writer = query.data;
-                ngx_unescape_uri(&writer, &r->args.data, r->args.len, 0);
+                u_char* reqargs = r->args.data;
+                ngx_unescape_uri(&writer, &reqargs, r->args.len, 0);
                 query.len = writer - query.data;
                 res = token_from_query(&query, &tkn);
         } else {


### PR DESCRIPTION
This PR fixes a bug in nginx-zauth-module. We pass the `&r->args.data` to `ngx_unescape_uri`, the pointer will be modified in `ngx_unescape_uri`, see https://github.com/nginx/nginx/blob/master/src/core/ngx_string.c#L1735. Then the argument variables in query string would lost in nginx script.

You can confirm the trouble by this way:

1. in nginx.conf, create such a `location`:

```
        location /bug {
            return 200 "bug is $arg_bug";
        }
```

2. visit this endpoint via curl: `curl -i -XGET http://localhost/bug?bug=zauth-bug`. You should get `bug is zauth-bug` however currently the value or this variable is null.
